### PR TITLE
退出登录取消菜单栏授权

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     //===========================================
     //============= Editor ======================
     //===========================================
-    "workbench.colorTheme": "Atom One Dark",
+    "workbench.colorTheme": "Default Dark+",
     "editor.smoothScrolling": true,
     "editor.cursorSmoothCaretAnimation": true,
     "diffEditor.ignoreTrimWhitespace": false,

--- a/src/layouts/dashboard/header/Navbar.tsx
+++ b/src/layouts/dashboard/header/Navbar.tsx
@@ -21,6 +21,7 @@ export default defineComponent({
                 message.warn('此功能暂未开放')
             } else if (key === 'logout') {
                 Cookies.remove('token')
+                store.commit('setAuthority', false)
                 push('/login')
             }
         }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -42,8 +42,8 @@ const store = createStore<GlobalData>({
         }
     },
     mutations: {
-        setAuthority(state) {
-            state.authorized = true
+        setAuthority(state, flag) {
+            state.authorized = flag
         },
         setAccessRoutes(state, accessRoutes) {
             state.accessRoutes = accessRoutes
@@ -84,7 +84,7 @@ const store = createStore<GlobalData>({
                 commit('setDict', dictRes.data)
                 /* OK */
 
-                commit('setAuthority')
+                commit('setAuthority', true)
                 commit('setAccessRoutes', data)
                 resolve()
             })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,18 @@ const viteConfig: UserConfig = {
             }
         }
     },
+    build: {
+        rollupOptions: {
+            external: ['vue', 'moment', 'ant-design-vue'],
+            output: {
+                paths: {
+                    vue: 'https://cdn.jsdelivr.net/npm/vue@3.0.7/dist/vue.esm-browser.prod.js',
+                    moment: 'https://cdn.jsdelivr.net/npm/moment@2.29.1/dist/moment.js',
+                    'ant-design-vue': 'https://cdn.jsdelivr.net/npm/ant-design-vue@2.0.1/dist/antd.js'
+                }
+            }
+        }
+    },
     server: {
         port: 3399,
         open: true


### PR DESCRIPTION
用户切换账号，菜单栏会沿用上次账号的权限，退出登录时应该取消菜单栏权限。